### PR TITLE
Nytt element `<lenke>` for digital post

### DIFF
--- a/eksempler/sdpMelding-digital.xml
+++ b/eksempler/sdpMelding-digital.xml
@@ -87,6 +87,11 @@
 				</repetisjoner>
 			</smsVarsel>
 		</varsler>
+        <lenke>
+            <url>https://www.avsender.no/svar</url>
+            <knappTekst lang="no">Svar på den viktige meldingen</knappTekst>
+            <frist>2017-10-01T12:00:00+02:00</frist>
+        </lenke>
 	</digitalPostInfo>
 
 	<dokumentpakkefingeravtrykk>

--- a/xsd/sdp-melding.xsd
+++ b/xsd/sdp-melding.xsd
@@ -109,6 +109,7 @@
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="varsler" type="Varsler" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="lenke" type="Lenke" minOccurs="0" maxOccurs="1"/>
 		</xsd:sequence>
 	</xsd:complexType>
 
@@ -196,6 +197,49 @@
 		<xsd:restriction base="xsd:string">
 			<xsd:minLength value="1"/>
 			<xsd:maxLength value="160"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:complexType name="Lenke">
+		<xsd:sequence>
+			<xsd:element name="url" type="HttpLenke" minOccurs="1" maxOccurs="1"/>
+			<xsd:element name="beskrivelse" type="LenkeBeskrivelseTekst" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="knappTekst" type="LenkeKnappTekst" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="frist" type="xsd:dateTime" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:simpleType name="HttpLenke">
+	  <xsd:restriction base="xsd:anyURI">
+	      <xsd:pattern value="https?://.+" />
+	  </xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:complexType name="LenkeBeskrivelseTekst">
+		<xsd:simpleContent>
+			<xsd:extension base="LenkeBeskrivelseTekstString">
+				<xsd:attribute name="lang" type="Spraakkode" use="required"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="LenkeBeskrivelseTekstString">
+		<xsd:restriction base="xsd:string">
+			<xsd:minLength value="1"/>
+			<xsd:maxLength value="70"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:complexType name="LenkeKnappTekst">
+		<xsd:simpleContent>
+			<xsd:extension base="LenkeKnappTekstString">
+				<xsd:attribute name="lang" type="Spraakkode" use="required"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="LenkeKnappTekstString">
+		<xsd:restriction base="xsd:string">
+			<xsd:minLength value="1"/>
+			<xsd:maxLength value="30"/>
 		</xsd:restriction>
 	</xsd:simpleType>
 


### PR DESCRIPTION
Innfører et frivillig elementet for å formidle en lenke til innbyggers
postkasse. Lenken inneholder alltid en http(s)-adresse (`url`) som blir
presentert til innbygger i postkassen.

Avsender kan i tillegg sende med noen frivillige elementer:

- `beskrivelse`: tekstlig beskrivelse som vises for innbyggeren.
- `knappTekst`: tekst på knappen som vises i postkassen. Postkasse-
leverandøren kan vise en standard-tekst dersom dette elementet mangler.
- `frist`: tidspunkt for når lenken «går ut på dato». Lenken vil aldri
gå ut på dato dersom elementet mangler.