### PR TITLE
Flytter `lenke`-elementet til manifestet i ASiC-pakken

### DIFF
--- a/eksempler/sdpManifest.xml
+++ b/eksempler/sdpManifest.xml
@@ -29,4 +29,11 @@
 		<tittel lang="no">journal</tittel>
 	</vedlegg>
 
+	<lenke>
+		<url>https://www.avsender.no/svar</url>
+        <beskrivelse lang="no">Vennligst svar på denne viktige meldingen for videre saksbehandling.</beskrivelse>
+		<knappTekst lang="no">Svar på den viktige meldingen</knappTekst>
+		<frist>2017-10-01T12:00:00+02:00</frist>
+	</lenke>
+
 </manifest>

--- a/eksempler/sdpMelding-digital.xml
+++ b/eksempler/sdpMelding-digital.xml
@@ -87,11 +87,6 @@
 				</repetisjoner>
 			</smsVarsel>
 		</varsler>
-        <lenke>
-            <url>https://www.avsender.no/svar</url>
-            <knappTekst lang="no">Svar på den viktige meldingen</knappTekst>
-            <frist>2017-10-01T12:00:00+02:00</frist>
-        </lenke>
 	</digitalPostInfo>
 
 	<dokumentpakkefingeravtrykk>

--- a/xsd/sdp-manifest.xsd
+++ b/xsd/sdp-manifest.xsd
@@ -19,6 +19,7 @@
 			<xsd:element name="avsender" type="Avsender" minOccurs="1" maxOccurs="1"/>
 			<xsd:element name="hoveddokument" type="Dokument" minOccurs="1" maxOccurs="1"/>
 			<xsd:element name="vedlegg" type="Dokument" minOccurs="0" maxOccurs="200"/>
+			<xsd:element name="lenke" type="Lenke" minOccurs="0" maxOccurs="1"/>
 		</xsd:sequence>
 	</xsd:complexType>
 
@@ -59,5 +60,48 @@
 			</xsd:simpleType>
 		</xsd:attribute>
 	</xsd:complexType>
+
+	<xsd:complexType name="Lenke">
+		<xsd:sequence>
+			<xsd:element name="url" type="HttpLenke" minOccurs="1" maxOccurs="1"/>
+			<xsd:element name="beskrivelse" type="LenkeBeskrivelseTekst" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="knappTekst" type="LenkeKnappTekst" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="frist" type="xsd:dateTime" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:simpleType name="HttpLenke">
+		<xsd:restriction base="xsd:anyURI">
+			<xsd:pattern value="https?://.+" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:complexType name="LenkeBeskrivelseTekst">
+		<xsd:simpleContent>
+			<xsd:extension base="LenkeBeskrivelseTekstString">
+				<xsd:attribute name="lang" type="Spraakkode" use="required"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="LenkeBeskrivelseTekstString">
+		<xsd:restriction base="xsd:string">
+			<xsd:minLength value="1"/>
+			<xsd:maxLength value="70"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:complexType name="LenkeKnappTekst">
+		<xsd:simpleContent>
+			<xsd:extension base="LenkeKnappTekstString">
+				<xsd:attribute name="lang" type="Spraakkode" use="required"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="LenkeKnappTekstString">
+		<xsd:restriction base="xsd:string">
+			<xsd:minLength value="1"/>
+			<xsd:maxLength value="30"/>
+		</xsd:restriction>
+	</xsd:simpleType>
 
 </xsd:schema>

--- a/xsd/sdp-melding.xsd
+++ b/xsd/sdp-melding.xsd
@@ -109,7 +109,6 @@
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="varsler" type="Varsler" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="lenke" type="Lenke" minOccurs="0" maxOccurs="1"/>
 		</xsd:sequence>
 	</xsd:complexType>
 
@@ -197,49 +196,6 @@
 		<xsd:restriction base="xsd:string">
 			<xsd:minLength value="1"/>
 			<xsd:maxLength value="160"/>
-		</xsd:restriction>
-	</xsd:simpleType>
-
-	<xsd:complexType name="Lenke">
-		<xsd:sequence>
-			<xsd:element name="url" type="HttpLenke" minOccurs="1" maxOccurs="1"/>
-			<xsd:element name="beskrivelse" type="LenkeBeskrivelseTekst" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="knappTekst" type="LenkeKnappTekst" minOccurs="0" maxOccurs="1"/>
-			<xsd:element name="frist" type="xsd:dateTime" minOccurs="0" maxOccurs="1"/>
-		</xsd:sequence>
-	</xsd:complexType>
-
-	<xsd:simpleType name="HttpLenke">
-	  <xsd:restriction base="xsd:anyURI">
-	      <xsd:pattern value="https?://.+" />
-	  </xsd:restriction>
-	</xsd:simpleType>
-
-	<xsd:complexType name="LenkeBeskrivelseTekst">
-		<xsd:simpleContent>
-			<xsd:extension base="LenkeBeskrivelseTekstString">
-				<xsd:attribute name="lang" type="Spraakkode" use="required"/>
-			</xsd:extension>
-		</xsd:simpleContent>
-	</xsd:complexType>
-	<xsd:simpleType name="LenkeBeskrivelseTekstString">
-		<xsd:restriction base="xsd:string">
-			<xsd:minLength value="1"/>
-			<xsd:maxLength value="70"/>
-		</xsd:restriction>
-	</xsd:simpleType>
-
-	<xsd:complexType name="LenkeKnappTekst">
-		<xsd:simpleContent>
-			<xsd:extension base="LenkeKnappTekstString">
-				<xsd:attribute name="lang" type="Spraakkode" use="required"/>
-			</xsd:extension>
-		</xsd:simpleContent>
-	</xsd:complexType>
-	<xsd:simpleType name="LenkeKnappTekstString">
-		<xsd:restriction base="xsd:string">
-			<xsd:minLength value="1"/>
-			<xsd:maxLength value="30"/>
 		</xsd:restriction>
 	</xsd:simpleType>
 


### PR DESCRIPTION
For å unngå at eventuelle sensitive data i beskrivelsen eller teksten på
knappen blir inkludert i `DigitalPost`-forretningsmeldinga flyttes
informasjonen til manifestet i ASiC-pakken. Dette er i tråd med hvordan
ikke-sensitiv tittel og «vanlig» (potensiell sensitiv) tittel for
dokumenter er håndtert.